### PR TITLE
Fix for mismatched createSession signature (Issue #16)

### DIFF
--- a/src/worker/interceptor.ts
+++ b/src/worker/interceptor.ts
@@ -34,7 +34,7 @@ return new URL(loginUrl);
 			const localState = await getState(provider);
 			const pkce = await getPkceVerifier(provider);
 
-			await createSession(params, provider, localState, pkce);
+			await createSession(params, provider, localState, url.origin, pkce);
 
 			// TODO: Add configurable login URL (hash is required!)
 			return new URL('#/', url.origin);


### PR DESCRIPTION
The signature of createSession in operations.ts is export async function createSession(params: string, provider: string, localState: string, host: string, pkce?: string)

However in interceptor.ts (line 37) this function is invoked like so await createSession(params, provider, localState, pkce);

(i.e there are 4 arguments rather than 5, and the variable pkce is passed as the value of host parameter.)

This naturally blows up downstream.

It seems to me this problem would affect any authorization-code based flow.